### PR TITLE
[FIX] Add support for LinkedIn URL shortener (lnkd.in)

### DIFF
--- a/examples/unshorten.rs
+++ b/examples/unshorten.rs
@@ -5,7 +5,9 @@ use urlexpand;
 async fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() == 1 {
-        println!("pass a url to expand: (eg: ./unhorten https://bit.ly/3alqLKi)");
+        println!("pass a url to expand:");
+        println!("  eg: ./unshorten https://bit.ly/3alqLKi");
+        println!("  eg: ./unshorten https://lnkd.in/eUeGcvsr");
         exit(1);
     }
     let url = args[1].to_owned();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ pub async fn unshorten(url: &str, timeout: Option<Duration>) -> Result<String> {
 
                 // Specific Resolvers
                 "adfoc.us" => resolvers::adfocus::unshort(&validated_url, timeout).await,
+                "lnkd.in" => resolvers::linkedin::unshort(&validated_url, timeout).await,
                 "shorturl.at" => resolvers::shorturl::unshort(&validated_url, timeout).await,
                 "surl.li" => resolvers::surlli::unshort(&validated_url, timeout).await,
 

--- a/src/resolvers/linkedin.rs
+++ b/src/resolvers/linkedin.rs
@@ -1,0 +1,45 @@
+// LinkedIn (lnkd.in) Resolver
+// LinkedIn is aggressive with anti-scraping and has two behaviors:
+// 1. Direct HTTP redirect (most common)
+// 2. Interstitial warning page with URL in HTML (when flagged/rate-limited)
+// We try both approaches for robustness
+
+use crate::resolvers::{from_url, generic};
+use futures::future::{ready, TryFutureExt};
+use std::time::Duration;
+
+use crate::{Error, Result};
+
+/// LinkedIn URL Expander
+pub(crate) async fn unshort(url: &str, timeout: Option<Duration>) -> Result<String> {
+    // First try standard HTTP redirect (most common LinkedIn behavior)
+    let expanded_url = generic::unshort(url, timeout).await?;
+
+    // If we're still on LinkedIn domain, try parsing the interstitial page
+    Ok(
+        if expanded_url.contains("linkedin.com") || expanded_url.contains("lnkd.in") {
+            match get_from_html(url, timeout).await {
+                Ok(u) => u,
+                Err(_) => expanded_url, // Fallback to whatever generic gave us
+            }
+        } else {
+            expanded_url
+        },
+    )
+}
+
+async fn get_from_html(url: &str, timeout: Option<Duration>) -> Result<String> {
+    from_url(url, timeout)
+        .and_then(|html| {
+            ready(
+                // Parse the interstitial warning page
+                html.split("data-tracking-control-name=\"external_url_click\"")
+                    .nth(1)
+                    .and_then(|r| r.split("href=\"").nth(1))
+                    .and_then(|r| r.split("\">").next())
+                    .map(|r| r.to_string())
+                    .ok_or(Error::NoString),
+            )
+        })
+        .await
+}

--- a/src/resolvers/mod.rs
+++ b/src/resolvers/mod.rs
@@ -5,6 +5,7 @@ use reqwest::{redirect::Policy, Client, ClientBuilder, StatusCode};
 pub(crate) mod adfly;
 pub(crate) mod adfocus;
 pub(crate) mod generic;
+pub(crate) mod linkedin;
 pub(crate) mod redirect;
 pub(crate) mod refresh;
 pub(crate) mod shorturl;

--- a/src/services.rs
+++ b/src/services.rs
@@ -1,6 +1,6 @@
 /// List of domains for some known
 /// URL shortening services.
-pub(crate) static SERVICES: [&str; 90] = [
+pub(crate) static SERVICES: [&str; 91] = [
     "adf.ly",
     "adfoc.us",
     "amzn.to",
@@ -40,6 +40,7 @@ pub(crate) static SERVICES: [&str; 90] = [
     "kutt.it",
     "ldn.im",
     "linklyhq.com",
+    "lnkd.in",
     "microify.com",
     "mzl.la",
     "nmc.sg",

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -189,6 +189,13 @@ test_shorten_link!(
 );
 
 test_shorten_link!(
+    test_lnkd_in,
+    "https://lnkd.in/g3T6zqDE",
+    starts_with,
+    "https://paulgraham.com"
+);
+
+test_shorten_link!(
     test_mlz_la,
     "https://mzl.la/3eqJ565",
     eq,


### PR DESCRIPTION
## Add LinkedIn URL shortener support (lnkd.in)

### Summary
  Adds support for LinkedIn's URL shortener service (`lnkd.in`) with a dedicated resolver to handle LinkedIn's aggressive anti-scraping measures.

  ### Changes
  - Added `lnkd.in` to services list (91 services total)
  - Created dedicated LinkedIn resolver (`src/resolvers/linkedin.rs`)
  - Added comprehensive test coverage for both async and blocking modes
  - Updated examples with working LinkedIn URL

### Why LinkedIn needs its own resolver

  LinkedIn is particularly aggressive with anti-scraping and bot detection, exhibiting **two distinct behaviors** depending on their rate-limiting and detection systems:

  1. **Standard HTTP redirect (most common)**
     - When not flagged, LinkedIn returns a standard HTTP 301/302 redirect
     - This is the fast path and works with the generic resolver

  2. **Interstitial warning page (when detected/rate-limited)**
     - When flagged, LinkedIn serves an HTML interstitial page with:
       - A warning message: "This link will take you to a page that's not on LinkedIn"
       - The actual destination URL embedded in an anchor tag with `data-tracking-control-name="external_url_click"`
     - This requires HTML parsing to extract the destination URL

  **The dedicated resolver handles both scenarios gracefully:**
  ```rust
  // First try HTTP redirect (fast path)
  let expanded_url = generic::unshort(url, timeout).await?;

  // If still on LinkedIn domain, parse interstitial page (robust path)
  if expanded_url.contains("linkedin.com") || expanded_url.contains("lnkd.in") {
      // Fall back to HTML parsing
  }
```
  This dual-strategy approach follows the same pattern as the existing surl.li resolver, which also handles multiple service behaviors.

### Testing

  - ✅ Tested with multiple LinkedIn shortened URLs
  - ✅ Both async (test_lnkd_in) and blocking (test_lnkd_in_blocking) tests pass
  - ✅ Example program verified with real LinkedIn URLs
  - ✅ Handles both HTTP redirect and interstitial page scenarios

### Example Usage

  cargo run --example unshorten -- https://lnkd.in/eUeGcvsr
  > Output: https://platform.valyu.ai/playground/deepresearch/...
